### PR TITLE
fix: correct getRouteIds function's return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ declare module "remix-custom-routes" {
       suffix?: string
       indexNames?: string[]
     },
-  ): string[]
+  ): [string, string][]
 
   export function getRouteManifest(
     sortedRouteIds: [string, string][],


### PR DESCRIPTION
The return type of the getRouteIds function must be `[string, string][]` instead of `string[]`.